### PR TITLE
Feature/public diary scroll query optimize

### DIFF
--- a/src/main/java/com/heartsave/todaktodak_api/domain/diary/cache/entity/ContentReactionCountEntity.java
+++ b/src/main/java/com/heartsave/todaktodak_api/domain/diary/cache/entity/ContentReactionCountEntity.java
@@ -4,6 +4,7 @@ import com.heartsave.todaktodak_api.domain.diary.domain.DiaryReactionCount;
 import com.heartsave.todaktodak_api.domain.diary.entity.projection.PublicDiaryContentProjection;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,8 +38,8 @@ public class ContentReactionCountEntity {
     return new ContentReactionCountEntity(projections);
   }
 
-  public void applyReactionCount(DiaryReactionCount count) {
-    this.reactionCount = count;
+  public void applyReactionCount(Map<Long, DiaryReactionCount> counts) {
+    this.reactionCount = counts.get(this.publicDiaryId);
   }
 
   public void updateWebtoonImageUrls(List<String> urls) {

--- a/src/main/java/com/heartsave/todaktodak_api/domain/diary/domain/DiaryReactionCount.java
+++ b/src/main/java/com/heartsave/todaktodak_api/domain/diary/domain/DiaryReactionCount.java
@@ -1,6 +1,9 @@
 package com.heartsave.todaktodak_api.domain.diary.domain;
 
 import com.heartsave.todaktodak_api.domain.diary.entity.projection.DiaryReactionCountProjection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,11 +18,19 @@ public class DiaryReactionCount {
   private Long empathize;
   private Long cheering;
 
-  public static DiaryReactionCount from(DiaryReactionCountProjection projection) {
-    return new DiaryReactionCount(
+  private DiaryReactionCount(DiaryReactionCountProjection projection) {
+    this(
         projection.getLikes(),
         projection.getSurprised(),
         projection.getEmpathize(),
         projection.getCheering());
+  }
+
+  public static Map<Long, DiaryReactionCount> from(List<DiaryReactionCountProjection> projections) {
+    Map<Long, DiaryReactionCount> result = new ConcurrentHashMap<>();
+    for (DiaryReactionCountProjection pro : projections) {
+      result.put(pro.getPublicDiaryId(), new DiaryReactionCount(pro));
+    }
+    return result;
   }
 }

--- a/src/main/java/com/heartsave/todaktodak_api/domain/diary/entity/projection/DiaryReactionCountProjection.java
+++ b/src/main/java/com/heartsave/todaktodak_api/domain/diary/entity/projection/DiaryReactionCountProjection.java
@@ -1,10 +1,15 @@
 package com.heartsave.todaktodak_api.domain.diary.entity.projection;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 반응 수 정보")
 public interface DiaryReactionCountProjection {
+
+  @Schema(description = "공개 일기 ID", example = "3")
+  @JsonIgnore
+  Long getPublicDiaryId();
 
   @Schema(description = "좋아요 수", example = "42")
   @JsonProperty("like")

--- a/src/test/java/com/heartsave/todaktodak_api/domain/diary/controller/MySharedDiaryControllerTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/domain/diary/controller/MySharedDiaryControllerTest.java
@@ -154,6 +154,11 @@ public class MySharedDiaryControllerTest {
         .thenReturn(
             new DiaryReactionCountProjection() {
               @Override
+              public Long getPublicDiaryId() {
+                return 0L;
+              }
+
+              @Override
               public Long getLikes() {
                 return 1L;
               }

--- a/src/test/java/com/heartsave/todaktodak_api/domain/diary/repository/DiaryReactionRepositoryTest.java
+++ b/src/test/java/com/heartsave/todaktodak_api/domain/diary/repository/DiaryReactionRepositoryTest.java
@@ -152,14 +152,22 @@ public class DiaryReactionRepositoryTest {
     diary = tem.find(DiaryEntity.class, diary.getId());
     System.out.println("diary.getDiaryCreatedTime() = " + diary.getDiaryCreatedTime());
     tem.remove(diary);
+    tem.flush();
+    tem.clear();
 
     DiaryReactionCountProjection result =
         diaryReactionRepository.countEachByPublicDiaryId(publicDiary.getId());
 
-    assertThat(result.getLikes()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
-    assertThat(result.getCheering()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
-    assertThat(result.getEmpathize()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
-    assertThat(result.getSurprised()).as("삭제된 일기의 반응 수가 조회되었습니다.").isEqualTo(0);
+    assertThat(result.getLikes()).as("삭제된 일기의 반응 수 %d회가 조회되었습니다.", result.getLikes()).isEqualTo(0);
+    assertThat(result.getCheering())
+        .as("삭제된 일기의 반응 수 %d회가 조회되었습니다.", result.getCheering())
+        .isEqualTo(0);
+    assertThat(result.getEmpathize())
+        .as("삭제된 일기의 반응 수 %d회가 조회되었습니다.", result.getEmpathize())
+        .isEqualTo(0);
+    assertThat(result.getSurprised())
+        .as("삭제된 일기의 반응 수 %d회가 조회되었습니다.", result.getSurprised())
+        .isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
## 공개 일기 무한 스크롤 API 쿼리 최적화 진행

기존 : 각 공개 일기 별로 Reaction 개수를 가져오는 쿼리가 발생
-> 현재 API 한 번에 5개의 공개 일기를 가져오기 때문에, __총 5번의 쿼리 발생__

변경 : 쿼리의 `IN` 키워드를 활용하여 공개 일기 ID들을 쿼리 하나에 담아서 진행.
-> 5번의 쿼리 발생을 __1번의 쿼리 발생으로 축소__